### PR TITLE
fix `link` example

### DIFF
--- a/link/build.sh
+++ b/link/build.sh
@@ -12,7 +12,7 @@ echo "⚙️  WAT to WASM ..."
 
 ${WASM_TOOLS_BIN} parse -o  ${OUT_DIR}/lib-c.wasm ./lib-c.wat
 ${WASM_TOOLS_BIN} parse -o  ${OUT_DIR}/lib-foo.wasm ./lib-foo.wat
-${WASM_TOOLS_BIN} parse -o  ${OUT_DIR}/lib-bar.wasm ./lib-bar.wat
+${WASM_TOOLS_BIN} component embed -o ${OUT_DIR}/lib-bar.wasm ./lib-bar.wit ./lib-bar.wat
 
 echo "⚙️  WASM to COMPONENT ..."
 

--- a/link/lib-bar.wit
+++ b/link/lib-bar.wit
@@ -1,0 +1,10 @@
+package test:test;
+
+interface test {
+   bar: func(v: s32) -> s32;
+}
+
+world lib-bar {
+    import test;
+    export test;
+}


### PR DESCRIPTION
This tells `wasm-tools` to embed lib-bar's component type (defined in lib-bar.wit) into out/lib-bar.wasm. `wasm tools component link` needs that to be able to construct the component.